### PR TITLE
Remove reflection from apache complex implementation

### DIFF
--- a/src/hypercomplex/cayley_dickson_construction.clj
+++ b/src/hypercomplex/cayley_dickson_construction.clj
@@ -97,12 +97,11 @@
         (init-construction
           (n-hypercomplex first-half-coeffs impl)
           (n-hypercomplex second-half-coeffs impl))))
-    (do
-      (let [err-str (str
-                      "n-complex requires coefficients count to be a power of 2. Provided: "
-                      (vec coeffs))]
-        (println
-          err-str)
-        (throw
-          (Exception.
-            err-str))))))
+    (let [err-str (str
+                    "n-complex requires coefficients count to be a power of 2. Provided: "
+                    (vec coeffs))]
+      (println
+        err-str)
+      (throw
+        (Exception.
+          err-str)))))

--- a/src/hypercomplex/core.clj
+++ b/src/hypercomplex/core.clj
@@ -1,6 +1,8 @@
 (ns hypercomplex.core
-  (:gen-class)
   (:import (org.apache.commons.math3.complex Complex)))
+
+(set! *unchecked-math* true)
+(set! *warn-on-reflection* true)
 
 (defprotocol Nion
   (init [this])
@@ -19,7 +21,6 @@
   (norm [this])
   (inv [this])
   (rot [this other]))
-
 
 (defn- nion-ops-mag [this]
   (->
@@ -77,30 +78,30 @@
     (assoc this :order 2
                 :obj (Complex. a b)))
   (c [this]
-    (let [cpx-cnj (.conjugate (:obj this))]
+    (let [cpx-cnj (.conjugate ^Complex (:obj this))]
       (assoc this :obj cpx-cnj
                   :a (.getReal cpx-cnj)
                   :b (.getImaginary cpx-cnj))))
   (neg [this]
-    (let [cpx-neg (.negate (:obj this))]
+    (let [cpx-neg (.negate ^Complex (:obj this))]
       (assoc this :obj cpx-neg
-                  :a (.getReal cpx-neg)
-                  :b (.getImaginary cpx-neg))))
+                  :a (.getReal ^Complex cpx-neg)
+                  :b (.getImaginary ^Complex cpx-neg))))
   (times [this other]
-    (let [cpx-times (.multiply (:obj this) (:obj other))]
+    (let [cpx-times (.multiply ^Complex (:obj this) ^Complex (:obj other))]
       (assoc this :obj cpx-times
-                  :a (.getReal cpx-times)
-                  :b (.getImaginary cpx-times))))
+                  :a (.getReal ^Complex cpx-times)
+                  :b (.getImaginary ^Complex cpx-times))))
   (plus [this other]
-    (let [cpx-add (.add (:obj this) (:obj other))]
+    (let [cpx-add (.add ^Complex (:obj this) ^Complex (:obj other))]
       (assoc this :obj cpx-add
-                  :a (.getReal cpx-add)
-                  :b (.getImaginary cpx-add))))
+                  :a (.getReal ^Complex cpx-add)
+                  :b (.getImaginary ^Complex cpx-add))))
   (minus [this other]
-    (let [cpx-subtract (.subtract (:obj this) (:obj other))]
+    (let [cpx-subtract (.subtract ^Complex (:obj this) ^Complex (:obj other))]
       (assoc this :obj cpx-subtract
-                  :a (.getReal cpx-subtract)
-                  :b (.getImaginary cpx-subtract))))
+                  :a (.getReal ^Complex cpx-subtract)
+                  :b (.getImaginary ^Complex cpx-subtract))))
   (valid-idx? [this idx]
     (if-not
       (and
@@ -258,8 +259,8 @@
                           2)
             new-idx    (mod idx half-order)]
         (if (< idx half-order)
-          (assoc this :a (set-idx (:a this) new-idx new-val))
-          (assoc this :b (set-idx (:b this) new-idx new-val))))))
+          (update-in this [:a] set-idx new-idx new-val)
+          (update-in this [:b] set-idx new-idx new-val)))))
 
   NionOps
   (mag [this]

--- a/test/hypercomplex/construction_test.clj
+++ b/test/hypercomplex/construction_test.clj
@@ -77,7 +77,7 @@
           (c/n-hypercomplex coeffs-5 :plain)
           #hypercomplex.core.Construction{:a #hypercomplex.core.Construction{:a #hypercomplex.core.Construction{:a #hypercomplex.core.Construction{:a #hypercomplex.core.Complex2{:a 0, :b 1, :order 2}, :b #hypercomplex.core.Complex2{:a 2, :b 3, :order 2}, :order 4}, :b #hypercomplex.core.Construction{:a #hypercomplex.core.Complex2{:a 4, :b 5, :order 2}, :b #hypercomplex.core.Complex2{:a 6, :b 7, :order 2}, :order 4}, :order 8}, :b #hypercomplex.core.Construction{:a #hypercomplex.core.Construction{:a #hypercomplex.core.Complex2{:a 8, :b 9, :order 2}, :b #hypercomplex.core.Complex2{:a 10, :b 11, :order 2}, :order 4}, :b #hypercomplex.core.Construction{:a #hypercomplex.core.Complex2{:a 12, :b 13, :order 2}, :b #hypercomplex.core.Complex2{:a 14, :b 15, :order 2}, :order 4}, :order 8}, :order 16}, :b #hypercomplex.core.Construction{:a #hypercomplex.core.Construction{:a #hypercomplex.core.Construction{:a #hypercomplex.core.Complex2{:a 16, :b 17, :order 2}, :b #hypercomplex.core.Complex2{:a 18, :b 19, :order 2}, :order 4}, :b #hypercomplex.core.Construction{:a #hypercomplex.core.Complex2{:a 20, :b 21, :order 2}, :b #hypercomplex.core.Complex2{:a 22, :b 23, :order 2}, :order 4}, :order 8}, :b #hypercomplex.core.Construction{:a #hypercomplex.core.Construction{:a #hypercomplex.core.Complex2{:a 24, :b 25, :order 2}, :b #hypercomplex.core.Complex2{:a 26, :b 27, :order 2}, :order 4}, :b #hypercomplex.core.Construction{:a #hypercomplex.core.Complex2{:a 28, :b 29, :order 2}, :b #hypercomplex.core.Complex2{:a 30, :b 31, :order 2}, :order 4}, :order 8}, :order 16}, :order 32}))
       #_(is
-        (=
-          (c/n-hypercomplex (range 4096) :plain)
-          {:too :many}))
+          (=
+            (c/n-hypercomplex (range 4096) :plain)
+            {:too :many}))
       )))


### PR DESCRIPTION
Using type hints. This speeds things up significantly: 
Before:
```lein test hypercomplex.load-test
Running load test using :plain impl:
"Elapsed time: 3112.046311 msecs"
Running load test using :apache impl:
"Elapsed time: 17657.669621 msecs"
```
After:
```lein test hypercomplex.load-test
Running load test using :plain impl:
"Elapsed time: 3080.116197 msecs"
Running load test using :apache impl:
"Elapsed time: 3703.578332 msecs"
```